### PR TITLE
✨ feat: 이메일 발송을 위한 member 도메인 연동

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -106,6 +106,10 @@ dependencies {
 	implementation "io.github.resilience4j:resilience4j-spring-boot3:2.3.0"
 	implementation "io.github.resilience4j:resilience4j-retry"
 	implementation "io.github.resilience4j:resilience4j-circuitbreaker"
+
+	// feign client
+	implementation platform("org.springframework.cloud:spring-cloud-dependencies:2025.0.0")
+	implementation "org.springframework.cloud:spring-cloud-starter-openfeign"
 }
 
 tasks.named('test') {

--- a/src/main/java/com/grow/payment_service/PaymentServiceApplication.java
+++ b/src/main/java/com/grow/payment_service/PaymentServiceApplication.java
@@ -2,8 +2,10 @@ package com.grow.payment_service;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableFeignClients
 @EnableScheduling
 @SpringBootApplication
 public class PaymentServiceApplication {

--- a/src/main/java/com/grow/payment_service/global/dto/RsData.java
+++ b/src/main/java/com/grow/payment_service/global/dto/RsData.java
@@ -2,14 +2,16 @@ package com.grow.payment_service.global.dto;
 
 import org.springframework.lang.NonNull;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.ToString;
+import lombok.NoArgsConstructor;
 
-@AllArgsConstructor
+@NoArgsConstructor
 @Getter
 @ToString
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -19,8 +21,19 @@ public class RsData<T> {
 	private String code;
 	@NonNull
 	private String msg;
-
 	private T data;
+
+	// Jackson 이 JSON 필드를 맵핑하도록 @JsonCreator
+	@JsonCreator
+	public RsData(
+		@JsonProperty("code") String code,
+		@JsonProperty("msg") String msg,
+		@JsonProperty("data") T data
+	) {
+		this.code = code;
+		this.msg  = msg;
+		this.data = data;
+	}
 
 	public RsData(String code, String msg) {
 		this(code, msg, null);

--- a/src/main/java/com/grow/payment_service/payment/application/dto/PaymentConfirmResponse.java
+++ b/src/main/java/com/grow/payment_service/payment/application/dto/PaymentConfirmResponse.java
@@ -8,4 +8,6 @@ import lombok.Getter;
 public class PaymentConfirmResponse  {
 	private final Long paymentId;
 	private final String payStatus;
+	private final String customerEmail;
+	private final String customerName;
 }

--- a/src/main/java/com/grow/payment_service/payment/application/service/impl/PaymentBatchServiceImpl.java
+++ b/src/main/java/com/grow/payment_service/payment/application/service/impl/PaymentBatchServiceImpl.java
@@ -7,6 +7,7 @@ import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.grow.payment_service.global.dto.RsData;
 import com.grow.payment_service.payment.application.dto.PaymentAutoChargeParam;
 import com.grow.payment_service.payment.application.dto.PaymentConfirmResponse;
 import com.grow.payment_service.payment.application.service.PaymentApplicationService;
@@ -148,7 +149,8 @@ public class PaymentBatchServiceImpl implements PaymentBatchService {
 			));
 
 			// 회원 서비스 호출 -> 이메일, 닉네임 조회
-			MemberInfoResponse profile = memberClient.getMyInfo(p.getMemberId());
+			RsData<MemberInfoResponse> memberResp = memberClient.getMyInfo(p.getMemberId());
+			MemberInfoResponse profile = memberResp.getData();
 			String customerEmail = profile.getEmail();
 			String customerName  = profile.getNickname();
 

--- a/src/main/java/com/grow/payment_service/payment/application/service/impl/PaymentPersistenceServiceImpl.java
+++ b/src/main/java/com/grow/payment_service/payment/application/service/impl/PaymentPersistenceServiceImpl.java
@@ -155,7 +155,9 @@ public class PaymentPersistenceServiceImpl implements PaymentPersistenceService 
 		paymentRepository.save(payment);
 		return new PaymentConfirmResponse(
 			payment.getPaymentId(),
-			payment.getPayStatus().name()
+			payment.getPayStatus().name(),
+			null,
+			null
 		);
 	}
 

--- a/src/main/java/com/grow/payment_service/payment/infra/client/MemberClient.java
+++ b/src/main/java/com/grow/payment_service/payment/infra/client/MemberClient.java
@@ -1,0 +1,18 @@
+package com.grow.payment_service.payment.infra.client;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+@FeignClient(name = "api-gateway", path = "/api/members")
+public interface MemberClient {
+
+	/**
+	 * 본인 정보 조회
+	 * @param memberId   X-Authorization-Id 헤더로 전달된 회원 ID
+	 */
+	@GetMapping("/me")
+	MemberInfoResponse getMyInfo(
+		@RequestHeader("X-Authorization-Id") Long memberId
+	);
+}

--- a/src/main/java/com/grow/payment_service/payment/infra/client/MemberClient.java
+++ b/src/main/java/com/grow/payment_service/payment/infra/client/MemberClient.java
@@ -4,7 +4,13 @@ import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
 
-@FeignClient(name = "api-gateway", path = "/api/members")
+import com.grow.payment_service.global.dto.RsData;
+
+@FeignClient(
+	name = "member-service",
+	url = "localhost:8080",
+	path = "/api/members"
+)
 public interface MemberClient {
 
 	/**
@@ -12,7 +18,7 @@ public interface MemberClient {
 	 * @param memberId   X-Authorization-Id 헤더로 전달된 회원 ID
 	 */
 	@GetMapping("/me")
-	MemberInfoResponse getMyInfo(
+	RsData<MemberInfoResponse> getMyInfo(
 		@RequestHeader("X-Authorization-Id") Long memberId
 	);
 }

--- a/src/main/java/com/grow/payment_service/payment/infra/client/MemberInfoResponse.java
+++ b/src/main/java/com/grow/payment_service/payment/infra/client/MemberInfoResponse.java
@@ -1,0 +1,14 @@
+package com.grow.payment_service.payment.infra.client;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class MemberInfoResponse {
+	private Long memberId;
+	private String email;
+	private String nickname;
+}

--- a/src/main/java/com/grow/payment_service/payment/presentation/TestMemberController.java
+++ b/src/main/java/com/grow/payment_service/payment/presentation/TestMemberController.java
@@ -1,0 +1,36 @@
+package com.grow.payment_service.payment.presentation;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.grow.payment_service.global.dto.RsData;
+import com.grow.payment_service.payment.infra.client.MemberClient;
+import com.grow.payment_service.payment.infra.client.MemberInfoResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/payments/test")
+@RequiredArgsConstructor
+public class TestMemberController {
+
+	private final MemberClient memberClient;
+
+	/**
+	 * 테스트용: 헤더의 X-Authorization-Id 로 멤버 정보 조회
+	 */
+	@GetMapping("/member-info")
+	public ResponseEntity<RsData<MemberInfoResponse>> getMemberInfo(
+		@RequestHeader("X-Authorization-Id") Long memberId
+	) {
+		// 1) 페이먼트 → 멤버 서비스 Feign 호출
+		RsData<MemberInfoResponse> resp = memberClient.getMyInfo(memberId);
+		// 2) 그대로 클라이언트에 리턴
+		return ResponseEntity.ok(
+			new RsData<>("200", "테스트용 멤버 정보 조회 성공", resp.getData())
+		);
+	}
+}

--- a/src/main/java/com/grow/payment_service/payment/saga/PaymentSagaOrchestrator.java
+++ b/src/main/java/com/grow/payment_service/payment/saga/PaymentSagaOrchestrator.java
@@ -85,7 +85,9 @@ public class PaymentSagaOrchestrator {
 				var existing = persistenceService.findByOrderId(param.getOrderId());
 				return new PaymentConfirmResponse(
 					Long.valueOf(prev),
-					existing.getPayStatus().name()
+					existing.getPayStatus().name(),
+					param.getCustomerEmail(),
+					param.getCustomerName()
 				);
 			}
 			// 아직 처리 중이면 중복 요청 예외 발생

--- a/src/test/java/com/grow/payment_service/payment/application/service/impl/PaymentApplicationServiceImplTest.java
+++ b/src/test/java/com/grow/payment_service/payment/application/service/impl/PaymentApplicationServiceImplTest.java
@@ -259,7 +259,7 @@ class PaymentApplicationServiceImplTest {
 			.customerEmail("email")
 			.customerName("name")
 			.build();
-		PaymentConfirmResponse dummy = new PaymentConfirmResponse(555L, "APPROVED");
+		PaymentConfirmResponse dummy = new PaymentConfirmResponse(555L, "APPROVED", "email", "name");
 		given(paymentSaga.autoChargeWithCompensation(param, "idem")).willReturn(dummy);
 
 		PaymentConfirmResponse res = service.chargeWithBillingKey(MEMBER_ID, param, "idem");

--- a/src/test/java/com/grow/payment_service/payment/application/service/impl/PaymentBatchServiceImplTest.java
+++ b/src/test/java/com/grow/payment_service/payment/application/service/impl/PaymentBatchServiceImplTest.java
@@ -1,6 +1,7 @@
 package com.grow.payment_service.payment.application.service.impl;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.*;
 
 import java.time.YearMonth;
@@ -9,35 +10,37 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-
 import com.grow.payment_service.global.exception.ErrorCode;
 import com.grow.payment_service.global.exception.PaymentApplicationException;
-import com.grow.payment_service.payment.application.service.PaymentApplicationService;
-import com.grow.payment_service.payment.domain.repository.PaymentRepository;
-import com.grow.payment_service.payment.infra.redis.RedisIdempotencyAdapter;
-import com.grow.payment_service.plan.domain.model.enums.PlanPeriod;
-import com.grow.payment_service.subscription.application.service.SubscriptionHistoryApplicationService;
 import com.grow.payment_service.payment.application.dto.PaymentAutoChargeParam;
 import com.grow.payment_service.payment.application.dto.PaymentConfirmResponse;
 import com.grow.payment_service.payment.domain.model.Payment;
 import com.grow.payment_service.payment.domain.model.PaymentHistory;
 import com.grow.payment_service.payment.domain.model.enums.PayStatus;
+import com.grow.payment_service.payment.infra.client.MemberClient;
+import com.grow.payment_service.payment.infra.client.MemberInfoResponse;
 import com.grow.payment_service.payment.domain.repository.PaymentHistoryRepository;
+import com.grow.payment_service.payment.domain.repository.PaymentRepository;
+import com.grow.payment_service.payment.infra.redis.RedisIdempotencyAdapter;
+import com.grow.payment_service.subscription.application.service.SubscriptionHistoryApplicationService;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class PaymentBatchServiceImplTest {
 
 	@Mock private PaymentRepository paymentRepository;
 	@Mock private PaymentHistoryRepository historyRepository;
-	@Mock private PaymentApplicationService paymentService;
+	@Mock private com.grow.payment_service.payment.application.service.PaymentApplicationService paymentService;
 	@Mock private RedisIdempotencyAdapter idempotencyAdapter;
 	@Mock private SubscriptionHistoryApplicationService subscriptionService;
+	@Mock private MemberClient memberClient;
 
 	@InjectMocks
 	private PaymentBatchServiceImpl batchService;
@@ -68,7 +71,7 @@ class PaymentBatchServiceImplTest {
 
 		then(paymentRepository).should().save(argThat(updated ->
 			updated.getBillingKey() == null &&
-			updated.getPayStatus() == PayStatus.ABORTED
+				updated.getPayStatus() == PayStatus.ABORTED
 		));
 		then(historyRepository).should()
 			.save(any(PaymentHistory.class));
@@ -102,7 +105,7 @@ class PaymentBatchServiceImplTest {
 
 		then(paymentRepository).should().save(argThat(cleared ->
 			cleared.getBillingKey() == null &&
-			cleared.getPayStatus() == PayStatus.ABORTED
+				cleared.getPayStatus() == PayStatus.ABORTED
 		));
 		then(historyRepository).should()
 			.save(any(PaymentHistory.class));
@@ -130,6 +133,7 @@ class PaymentBatchServiceImplTest {
 	@Test
 	@DisplayName("processSingleAutoCharge: 성공 흐름")
 	void processSingleAutoCharge_success() {
+		// 준비: payment 레코드
 		Payment p = Payment.of(
 			5L, 50L, 500L, "ord-5", null,
 			"bKey", "cust_50", 2500L,
@@ -140,15 +144,39 @@ class PaymentBatchServiceImplTest {
 		given(idempotencyAdapter.getOrCreateKey(anyString())).willReturn("idem");
 		given(idempotencyAdapter.reserve("idem")).willReturn(true);
 
-		PaymentConfirmResponse confirmRes = new PaymentConfirmResponse(5L, PayStatus.AUTO_BILLING_APPROVED.name());
-		given(paymentService.chargeWithBillingKey(eq(50L), any(PaymentAutoChargeParam.class), eq("idem")))
-			.willReturn(confirmRes);
+		// 준비: memberClient stub
+		given(memberClient.getMyInfo(50L))
+			.willReturn(new MemberInfoResponse(50L, "foo@ex.com", "FooNick"));
 
+		// 준비: paymentService stub
+		PaymentConfirmResponse confirmRes = new PaymentConfirmResponse(
+			5L,
+			PayStatus.AUTO_BILLING_APPROVED.name(),
+			"foo@ex.com",
+			"FooNick"
+		);
+		given(paymentService.chargeWithBillingKey(
+			eq(50L),
+			any(PaymentAutoChargeParam.class),
+			eq("idem")
+		)).willReturn(confirmRes);
+
+		// 실행
 		batchService.processSingleAutoCharge(5L);
 
+		// 검증: state transitions 저장
 		then(paymentRepository).should(times(3)).save(any(Payment.class));
 		then(historyRepository).should(times(3)).save(any(PaymentHistory.class));
-		then(paymentService).should().chargeWithBillingKey(eq(50L), any(PaymentAutoChargeParam.class), eq("idem"));
+
+		// 검증: 실제 호출된 param 에 이메일·이름 반영
+		ArgumentCaptor<PaymentAutoChargeParam> captor =
+			ArgumentCaptor.forClass(PaymentAutoChargeParam.class);
+		then(paymentService)
+			.should()
+			.chargeWithBillingKey(eq(50L), captor.capture(), eq("idem"));
+		PaymentAutoChargeParam used = captor.getValue();
+		assertEquals("foo@ex.com", used.getCustomerEmail());
+		assertEquals("FooNick",    used.getCustomerName());
 	}
 
 	@Test

--- a/src/test/java/com/grow/payment_service/payment/application/service/impl/PaymentBatchServiceImplTest.java
+++ b/src/test/java/com/grow/payment_service/payment/application/service/impl/PaymentBatchServiceImplTest.java
@@ -10,6 +10,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
+import com.grow.payment_service.global.dto.RsData;
 import com.grow.payment_service.global.exception.ErrorCode;
 import com.grow.payment_service.global.exception.PaymentApplicationException;
 import com.grow.payment_service.payment.application.dto.PaymentAutoChargeParam;
@@ -144,9 +145,10 @@ class PaymentBatchServiceImplTest {
 		given(idempotencyAdapter.getOrCreateKey(anyString())).willReturn("idem");
 		given(idempotencyAdapter.reserve("idem")).willReturn(true);
 
-		// 준비: memberClient stub
+		// 준비: memberClient stub —> RsData 로 감싸서 반환
+		MemberInfoResponse memberDto = new MemberInfoResponse(50L, "foo@ex.com", "FooNick");
 		given(memberClient.getMyInfo(50L))
-			.willReturn(new MemberInfoResponse(50L, "foo@ex.com", "FooNick"));
+			.willReturn(new RsData<>("200", "OK", memberDto));
 
 		// 준비: paymentService stub
 		PaymentConfirmResponse confirmRes = new PaymentConfirmResponse(


### PR DESCRIPTION
## 🔍 Title(필수)
#18 

## 🔗 Related Issues(필수)
Closes #18 

## 📝 Note (주의 사항)
토스 페이먼츠 자동 결제는 고객의 이메일과 이름을 파라미터로 받아 결제 시 자동으로 메일 보내준다고 해서, 멤버의 이메일과 이름을 받기 위해 멤버 도메인의 /me에서 feign 클라이언트 연결을 통해 가져오고, 자동으로 자동 결제 배치 서비스 시 파라미터에 이메일과 이름을 넣도록 수정했습니다.
-> 이런 방식으로 하는게 맞는지만 봐주세요... 
일반 결제는 웹훅을 연동해서 이메일 전송을 해야할 것 같습니다


1. PaymentAutoChargeParam DTO 확장
- customerEmail, customerName 필드 추가
- 토스페이먼츠 자동결제 API에 이메일·이름 전달 가능하도록 변경

2. Feign 클라이언트로 멤버 서비스 연동
- MemberClient 인터페이스 추가

3. 배치 서비스(PaymentBatchServiceImpl) 수정
- Quartz Job 처리 시 memberClient.getMyInfo() 호출
- 반환된 이메일·이름을 PaymentAutoChargeParam 에 세팅
- paymentService.chargeWithBillingKey(...) 호출 시 토스페이먼츠가 자동으로 영수증 메일 발송