### PR TITLE
✨ feat: 결제 알림 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,8 @@ def jacocoExcludes = [
 		'**/init/**',
 		'**/PaymentServiceApplication.class',
 		'**/paymentprovider/**',
-		'**/SubscriptionHistoryInitDataLoader.class'
+		'**/SubscriptionHistoryInitDataLoader.class',
+		'**/event/**'
 ]
 
 jacocoTestCoverageVerification {

--- a/src/main/java/com/grow/payment_service/payment/application/dto/PaymentConfirmResponse.java
+++ b/src/main/java/com/grow/payment_service/payment/application/dto/PaymentConfirmResponse.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 public class PaymentConfirmResponse  {
 	private final Long paymentId;
 	private final String payStatus;
+	private String paymentKey;
 	private final String customerEmail;
 	private final String customerName;
 }

--- a/src/main/java/com/grow/payment_service/payment/application/event/PaymentEvent.java
+++ b/src/main/java/com/grow/payment_service/payment/application/event/PaymentEvent.java
@@ -1,0 +1,18 @@
+package com.grow.payment_service.payment.application.event;
+
+import java.time.LocalDateTime;
+
+/**
+ * 결제 관련 알림을 위한 이벤트 객체
+ */
+public record PaymentEvent(
+	Long memberId,
+	String type,
+	String code,
+	String title,
+	String content,
+	String orderId,
+	Integer amount,
+	LocalDateTime occurredAt
+) {
+}

--- a/src/main/java/com/grow/payment_service/payment/application/event/PaymentNotificationEventHandler.java
+++ b/src/main/java/com/grow/payment_service/payment/application/event/PaymentNotificationEventHandler.java
@@ -1,0 +1,40 @@
+package com.grow.payment_service.payment.application.event;
+
+import static org.springframework.transaction.event.TransactionPhase.*;
+
+
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import com.grow.payment_service.payment.infra.client.NotificationClient;
+import com.grow.payment_service.payment.infra.client.NotificationRequest;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PaymentNotificationEventHandler {
+
+	private final NotificationClient notificationClient;
+
+	@TransactionalEventListener(phase = AFTER_COMMIT)
+	public void on(PaymentEvent e) {
+		Long amountLong = e.amount() == null ? null : e.amount().longValue();
+
+		NotificationRequest req = NotificationRequest.builder()
+			.notificationType("PAYMENT")
+			.memberId(e.memberId())
+			.title(e.title())
+			.content(e.content())
+			.orderId(e.orderId())
+			.amount(amountLong)
+			.occurredAt(e.occurredAt())
+			.build();
+
+		notificationClient.sendPaymentEvent(req);
+		log.info("[알림 전송] type={}, code={}, memberId={}, orderId={}", e.type(), e.code(), e.memberId(), e.orderId());
+	}
+}

--- a/src/main/java/com/grow/payment_service/payment/application/event/PaymentNotificationPublisher.java
+++ b/src/main/java/com/grow/payment_service/payment/application/event/PaymentNotificationPublisher.java
@@ -1,0 +1,91 @@
+package com.grow.payment_service.payment.application.event;
+
+import java.time.LocalDateTime;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class PaymentNotificationPublisher {
+
+	private static final String TYPE = "PAYMENT";
+	private final ApplicationEventPublisher events;
+
+	private void publish(
+		Long memberId,
+		String code,
+		String title,
+		String content,
+		String orderId,
+		Integer amount
+	) {
+		PaymentEvent event = new PaymentEvent(
+			memberId,
+			TYPE,
+			code,
+			title,
+			content,
+			orderId,
+			amount,
+			LocalDateTime.now()
+		);
+		events.publishEvent(event);
+	}
+
+	/** 결제 승인 성공 */
+	public void paymentApproved(Long memberId, String orderId, int amount) {
+		String title = "결제가 완료되었습니다";
+		String content = "주문 " + orderId + " 결제가 완료되었어요.";
+		publish(memberId, "APPROVED", title, content, orderId, Integer.valueOf(amount));
+	}
+
+	/** 결제 실패 */
+	public void paymentFailed(Long memberId, String orderId, int amount) {
+		String title = "결제가 실패했습니다";
+		String content = "주문 " + orderId + " 결제가 실패했어요. 다시 시도해 주세요.";
+		publish(memberId, "FAILED", title, content, orderId, Integer.valueOf(amount));
+	}
+
+	/** 결제 취소 요청 접수(필요 시 사용) */
+	public void cancelRequested(Long memberId, String orderId, int amount) {
+		String title = "결제 취소 요청 접수";
+		String content = "주문 " + orderId + " 취소 요청을 접수했어요.";
+		publish(memberId, "CANCEL_REQUESTED", title, content, orderId, Integer.valueOf(amount));
+	}
+
+	/** 결제 취소 완료 */
+	public void cancelled(Long memberId, String orderId, int amount) {
+		String title = "결제가 취소되었습니다";
+		String content = "주문 " + orderId + " 결제가 취소되었어요.";
+		publish(memberId, "CANCELLED", title, content, orderId, Integer.valueOf(amount));
+	}
+
+	/** 자동결제 등록 완료(빌링키 발급) */
+	public void billingKeyIssued(Long memberId, String orderId) {
+		String title = "자동결제 등록 완료";
+		String content = "주문 " + orderId + " 자동결제가 등록되었어요.";
+		publish(memberId, "BILLING_KEY_ISSUED", title, content, orderId, null);
+	}
+
+	/** 자동결제 승인 완료 */
+	public void autoBillingApproved(Long memberId, String orderId, int amount) {
+		String title = "자동결제 완료";
+		String content = "주문 " + orderId + " 자동결제가 완료되었어요.";
+		publish(memberId, "AUTO_BILLING_APPROVED", title, content, orderId, Integer.valueOf(amount));
+	}
+
+	/** 자동결제 실패 */
+	public void autoBillingFailed(Long memberId, String orderId, int amount) {
+		String title = "자동결제 실패";
+		String content = "주문 " + orderId + " 자동결제가 실패했어요. 결제수단을 확인해 주세요.";
+		publish(memberId, "AUTO_BILLING_FAILED", title, content, orderId, Integer.valueOf(amount));
+	}
+
+	/** 구독 해지 예약(7일 초과 정책 등) */
+	public void cancelScheduled(Long memberId, String orderId) {
+		String title = "구독 해지 예약";
+		String content = "주문 " + orderId + "은 이번 달까지 이용되고 다음 달부터 청구되지 않아요.";
+		publish(memberId, "SUBSCRIPTION_CANCEL_SCHEDULED", title, content, orderId, null);
+	}
+}

--- a/src/main/java/com/grow/payment_service/payment/application/event/PaymentNotificationPublisher.java
+++ b/src/main/java/com/grow/payment_service/payment/application/event/PaymentNotificationPublisher.java
@@ -40,7 +40,7 @@ public class PaymentNotificationPublisher {
 		publish(memberId, "APPROVED", title, content, orderId, Integer.valueOf(amount));
 	}
 
-	/** 결제 실패 */
+	/** 결제 실패(필요 시 사용) */
 	public void paymentFailed(Long memberId, String orderId, int amount) {
 		String title = "결제가 실패했습니다";
 		String content = "주문 " + orderId + " 결제가 실패했어요. 다시 시도해 주세요.";

--- a/src/main/java/com/grow/payment_service/payment/application/service/PaymentApplicationService.java
+++ b/src/main/java/com/grow/payment_service/payment/application/service/PaymentApplicationService.java
@@ -25,7 +25,6 @@ public interface PaymentApplicationService {
 	/** 결제 취소 요청 처리(외부 API 호출 + 퍼시스턴스 분리) */
 	PaymentCancelResponse cancelPayment(
 		Long memberId,
-		String paymentKey,
 		String orderId,
 		int cancelAmount,
 		CancelReason cancelReason

--- a/src/main/java/com/grow/payment_service/payment/application/service/PaymentPersistenceService.java
+++ b/src/main/java/com/grow/payment_service/payment/application/service/PaymentPersistenceService.java
@@ -12,7 +12,7 @@ import com.grow.payment_service.payment.infra.paymentprovider.dto.TossBillingCha
 public interface PaymentPersistenceService {
 
 	/** 결제 승인 후 DB 저장 */
-	Long savePaymentConfirmation(String orderId);
+	Long savePaymentConfirmation(String orderId, String paymentKey);
 
 	/** 결제 취소 요청 후 DB 저장 */
 	PaymentCancelResponse requestCancel(String orderId, CancelReason reason, int amount);

--- a/src/main/java/com/grow/payment_service/payment/application/service/impl/PaymentApplicationServiceImpl.java
+++ b/src/main/java/com/grow/payment_service/payment/application/service/impl/PaymentApplicationServiceImpl.java
@@ -166,7 +166,6 @@ public class PaymentApplicationServiceImpl implements PaymentApplicationService 
 	@Transactional
 	public PaymentCancelResponse cancelPayment(
 		Long memberId,
-		String paymentKey,
 		String orderId,
 		int cancelAmount,
 		CancelReason reason
@@ -181,6 +180,13 @@ public class PaymentApplicationServiceImpl implements PaymentApplicationService 
 		paid.verifyOwnership(memberId);
 		log.info("[1/2] 소유권 검증 완료 → memberId={} owns orderId={}",
 			memberId, orderId);
+
+		// 서버에서 paymentKey 조회
+		String paymentKey = paid.getPaymentKey();
+		if (paymentKey == null || paymentKey.isBlank()) {
+			log.error("취소 불가: paymentKey 없음 → orderId={}", orderId);
+			throw new PaymentApplicationException(ErrorCode.PAYMENT_CANCEL_ERROR);
+		}
 
 		// [2/2] SAGA 결제 취소 호출
 		log.info("[2/2] SAGA 결제 취소 호출 → paymentKey={}, orderId={}, cancelAmount={}, reason={}",

--- a/src/main/java/com/grow/payment_service/payment/application/service/impl/PaymentApplicationServiceImpl.java
+++ b/src/main/java/com/grow/payment_service/payment/application/service/impl/PaymentApplicationServiceImpl.java
@@ -10,6 +10,7 @@ import com.grow.payment_service.global.dto.RsData;
 import com.grow.payment_service.global.exception.ErrorCode;
 import com.grow.payment_service.global.exception.PaymentApplicationException;
 import com.grow.payment_service.payment.application.dto.*;
+import com.grow.payment_service.payment.application.event.PaymentNotificationPublisher;
 import com.grow.payment_service.payment.application.service.PaymentApplicationService;
 import com.grow.payment_service.payment.domain.model.Payment;
 import com.grow.payment_service.payment.domain.model.PaymentHistory;
@@ -34,15 +35,16 @@ import lombok.extern.slf4j.Slf4j;
 public class PaymentApplicationServiceImpl implements PaymentApplicationService {
 
 	private static final String SUCCESS_URL = "http://localhost:3000/me/payment/success";
-	private static final String FAIL_URL    = "http://localhost:3000/me/payment/fail";
+	private static final String FAIL_URL = "http://localhost:3000/me/payment/fail";
 
-	private final PlanRepository                  planRepository;
-	private final OrderIdGenerator                orderIdGenerator;
-	private final PaymentRepository               paymentRepository;
-	private final PaymentHistoryRepository        historyRepository;
-	private final PaymentSagaOrchestrator         paymentSaga;
+	private final PlanRepository planRepository;
+	private final OrderIdGenerator orderIdGenerator;
+	private final PaymentRepository paymentRepository;
+	private final PaymentHistoryRepository historyRepository;
+	private final PaymentSagaOrchestrator paymentSaga;
 	private final SubscriptionHistoryApplicationService subscriptionService;
-	private final MemberClient                    memberClient;
+	private final MemberClient memberClient;
+	private final PaymentNotificationPublisher publisher;
 
 	/**
 	 * 주문 DB 생성 후 클라이언트에게 데이터 반환
@@ -66,7 +68,7 @@ public class PaymentApplicationServiceImpl implements PaymentApplicationService 
 				memberId, planId, orderId,
 				null, null,
 				"cust_" + memberId,
-				(long) amount,
+				(long)amount,
 				"CARD"
 			);
 			payment = paymentRepository.save(payment);
@@ -122,7 +124,7 @@ public class PaymentApplicationServiceImpl implements PaymentApplicationService 
 		RsData<MemberInfoResponse> rs = memberClient.getMyInfo(memberId);
 		MemberInfoResponse profile = rs.getData();
 		String customerEmail = profile.getEmail();
-		String customerName  = profile.getNickname();
+		String customerName = profile.getNickname();
 		log.info("[1/4] 멤버 정보 조회 완료 → email={}, nickname={}",
 			customerEmail, customerName);
 
@@ -138,6 +140,9 @@ public class PaymentApplicationServiceImpl implements PaymentApplicationService 
 			customerName
 		);
 		log.info("[2/4] SAGA 결제 승인 완료 → paymentId={}", paymentId);
+
+		// 결제 승인 알림
+		publisher.paymentApproved(memberId, orderId, amount);
 
 		// [3/4] 주문 조회 & 소유권 검증
 		log.info("[3/4] 주문 조회 및 소유권 검증 → paymentId={}", paymentId);
@@ -225,6 +230,10 @@ public class PaymentApplicationServiceImpl implements PaymentApplicationService 
 					);
 					log.info("[2/2] SAGA 결제 취소 완료 → paymentKey={}, orderId={}",
 						paymentKey, orderId);
+
+					// 결제 취소 알림
+					publisher.cancelled(memberId, orderId, fullAmount);
+
 					return res;
 				} catch (Exception ex) {
 					log.error("결제 취소 실패: paymentKey={}, orderId={}, cancelAmount={}",
@@ -253,6 +262,9 @@ public class PaymentApplicationServiceImpl implements PaymentApplicationService 
 						)
 					);
 
+					// 7일 초과 결제 취소 알림
+					publisher.cancelScheduled(memberId, orderId);
+
 					return new PaymentCancelResponse(
 						toSave.getPaymentId(),
 						toSave.getPayStatus().name()
@@ -280,6 +292,10 @@ public class PaymentApplicationServiceImpl implements PaymentApplicationService 
 			);
 			log.info("[2/2] SAGA 결제 취소 완료 → paymentKey={}, orderId={}",
 				paymentKey, orderId);
+
+			// 결제 취소 알림
+			publisher.cancelled(memberId, orderId, cancelAmount);
+
 			return res;
 		} catch (Exception ex) {
 			log.error("결제 취소 실패: paymentKey={}, orderId={}, cancelAmount={}",
@@ -320,6 +336,10 @@ public class PaymentApplicationServiceImpl implements PaymentApplicationService 
 			PaymentIssueBillingKeyResponse res = paymentSaga.issueKeyWithCompensation(param);
 			log.info("[2/2] SAGA 빌링키 발급 완료 → orderId={}, billingKey={}",
 				param.getOrderId(), res.getBillingKey());
+
+			// 자동결제 승인 알림
+			publisher.billingKeyIssued(memberId, param.getOrderId());
+
 			return res;
 		} catch (Exception ex) {
 			log.error("빌링키 발급 실패: orderId={}", param.getOrderId(), ex);
@@ -361,6 +381,10 @@ public class PaymentApplicationServiceImpl implements PaymentApplicationService 
 		try {
 			PaymentConfirmResponse res = paymentSaga.autoChargeWithCompensation(param, idempotencyKey);
 			log.info("[2/3] SAGA 자동결제 완료 → paymentId={}", res.getPaymentId());
+
+			// 자동결제 승인 알림
+			publisher.autoBillingApproved(memberId, param.getOrderId(), param.getAmount());
+
 			// [3/3] 결과 반환
 			log.info("[3/3] 자동결제 응답 반환 → paymentId={}", res.getPaymentId());
 			return res;
@@ -394,6 +418,7 @@ public class PaymentApplicationServiceImpl implements PaymentApplicationService 
 			log.info("[주문 만료 스킵] orderId={}, status={}", orderId, p.getPayStatus());
 		}
 	}
+
 	/**
 	 * 테스트용 빌링키 발급 상태 전이 메서드
 	 */

--- a/src/main/java/com/grow/payment_service/payment/application/service/impl/PaymentApplicationServiceImpl.java
+++ b/src/main/java/com/grow/payment_service/payment/application/service/impl/PaymentApplicationServiceImpl.java
@@ -141,9 +141,6 @@ public class PaymentApplicationServiceImpl implements PaymentApplicationService 
 		);
 		log.info("[2/4] SAGA 결제 승인 완료 → paymentId={}", paymentId);
 
-		// 결제 승인 알림
-		publisher.paymentApproved(memberId, orderId, amount);
-
 		// [3/4] 주문 조회 & 소유권 검증
 		log.info("[3/4] 주문 조회 및 소유권 검증 → paymentId={}", paymentId);
 		Payment paid = paymentRepository.findById(paymentId)
@@ -151,6 +148,9 @@ public class PaymentApplicationServiceImpl implements PaymentApplicationService 
 		paid.verifyOwnership(memberId);
 		log.info("[3/4] 소유권 검증 완료 → memberId={} owns paymentId={}",
 			memberId, paymentId);
+
+		// 결제 승인 알림
+		publisher.paymentApproved(memberId, orderId, amount);
 
 		// [4/4] 구독 플랜 갱신 처리
 		log.info("[4/4] Plan 조회 → planId={}", paid.getPlanId());

--- a/src/main/java/com/grow/payment_service/payment/application/service/impl/PaymentApplicationServiceImpl.java
+++ b/src/main/java/com/grow/payment_service/payment/application/service/impl/PaymentApplicationServiceImpl.java
@@ -216,7 +216,7 @@ public class PaymentApplicationServiceImpl implements PaymentApplicationService 
 					? cancelAmount
 					: paid.getTotalAmount().intValue();
 
-				// [2/2] SAGA 결제 취소 호출 → (로그/주석 유지)
+				// [2/2] SAGA 결제 취소 호출
 				log.info("[2/2] SAGA 결제 취소 호출 → paymentKey={}, orderId={}, cancelAmount={}, reason={}",
 					paymentKey, orderId, fullAmount, reason);
 				try {

--- a/src/main/java/com/grow/payment_service/payment/application/service/impl/PaymentPersistenceServiceImpl.java
+++ b/src/main/java/com/grow/payment_service/payment/application/service/impl/PaymentPersistenceServiceImpl.java
@@ -141,12 +141,14 @@ public class PaymentPersistenceServiceImpl implements PaymentPersistenceService 
 		Payment payment = paymentRepository.findByOrderId(orderId)
 			.orElseThrow(() -> new PaymentApplicationException(ErrorCode.ORDER_NOT_FOUND));
 		if ("DONE".equals(tossRes.getStatus())) {
-			payment = payment.approveAutoBilling();
+			//  paymentKey 반영 + 승인 전이
+			payment = payment.approveAutoBilling(tossRes.getPaymentKey());
+
 			historyRepository.save(
 				PaymentHistory.create(
 					payment.getPaymentId(),
 					payment.getPayStatus(),
-					"자동결제 승인 완료"
+					"자동결제 승인 완료" + " (paymentKey=" + payment.getPaymentKey() + ")"
 				)
 			);
 		} else {
@@ -163,6 +165,7 @@ public class PaymentPersistenceServiceImpl implements PaymentPersistenceService 
 		return new PaymentConfirmResponse(
 			payment.getPaymentId(),
 			payment.getPayStatus().name(),
+			tossRes.getPaymentKey(),
 			null,
 			null
 		);

--- a/src/main/java/com/grow/payment_service/payment/domain/exception/PaymentDomainException.java
+++ b/src/main/java/com/grow/payment_service/payment/domain/exception/PaymentDomainException.java
@@ -29,4 +29,10 @@ public class PaymentDomainException extends RuntimeException {
 			String.format("접근 권한이 없습니다. memberId=%d", memberId)
 		);
 	}
+
+	public static PaymentDomainException InvalidPaymentKey(String paymentKey) {
+		return new PaymentDomainException(
+			String.format("유효하지 않은 PaymentKey 입니다. paymentKey=%s", paymentKey)
+		);
+	}
 }

--- a/src/main/java/com/grow/payment_service/payment/domain/model/Payment.java
+++ b/src/main/java/com/grow/payment_service/payment/domain/model/Payment.java
@@ -215,6 +215,53 @@ public class Payment {
 		}
 	}
 
+	/** 일반 결제 승인: paymentKey 저장 + READY -> DONE 전이 */
+	public Payment approve(String paymentKey) {
+		if (paymentKey == null || paymentKey.isBlank()) {
+			throw PaymentDomainException.invalidStatusTransition(this.payStatus, DONE);
+		}
+		if (!this.payStatus.canTransitionTo(DONE)) {
+			throw PaymentDomainException.InvalidPaymentKey(paymentKey);
+		}
+		return new Payment(
+			this.paymentId,
+			this.memberId,
+			this.planId,
+			this.orderId,
+			paymentKey,
+			this.billingKey,
+			this.customerKey,
+			this.totalAmount,
+			DONE,
+			this.method,
+			null,
+			null
+		);
+	}
+
+	/** 미결제 만료: READY -> ABORTED 전이 */
+	public Payment expire() {
+		if (!this.payStatus.canTransitionTo(ABORTED)) {
+			throw PaymentDomainException.invalidStatusTransition(this.payStatus, ABORTED);
+		}
+		return new Payment(
+			this.paymentId,
+			this.memberId,
+			this.planId,
+			this.orderId,
+			this.paymentKey,
+			this.billingKey,
+			this.customerKey,
+			this.totalAmount,
+			ABORTED,
+			this.method,
+			null,
+			this.cancelReason
+		);
+	}
+
+
+
 	public static Payment of(Long paymentId, Long memberId, Long planId, String orderId,
 		String paymentKey, String billingKey, String customerKey,
 		Long totalAmount, PayStatus payStatus, String method,

--- a/src/main/java/com/grow/payment_service/payment/domain/model/Payment.java
+++ b/src/main/java/com/grow/payment_service/payment/domain/model/Payment.java
@@ -113,14 +113,19 @@ public class Payment {
 		);
 	}
 
-	/** 자동결제 승인 후 상태 전이 */
-	public Payment approveAutoBilling() {
-		if (!this.payStatus.canTransitionTo(AUTO_BILLING_APPROVED))
+	/** 자동결제 승인: paymentKey 저장 + 상태 전이 */
+	public Payment approveAutoBilling(String paymentKey) {
+		if (paymentKey == null || paymentKey.isBlank()) {
+			throw PaymentDomainException.InvalidPaymentKey(paymentKey);
+		}
+		if (!this.payStatus.canTransitionTo(AUTO_BILLING_APPROVED)) {
 			throw PaymentDomainException.invalidStatusTransition(this.payStatus, AUTO_BILLING_APPROVED);
+		}
 		return new Payment(
 			paymentId, memberId, planId, orderId,
-			paymentKey, billingKey, customerKey,
-			totalAmount, PayStatus.AUTO_BILLING_APPROVED,
+			paymentKey,
+			billingKey, customerKey,
+			totalAmount, AUTO_BILLING_APPROVED,
 			method, failureReason, cancelReason
 		);
 	}

--- a/src/main/java/com/grow/payment_service/payment/domain/model/Payment.java
+++ b/src/main/java/com/grow/payment_service/payment/domain/model/Payment.java
@@ -218,10 +218,10 @@ public class Payment {
 	/** 일반 결제 승인: paymentKey 저장 + READY -> DONE 전이 */
 	public Payment approve(String paymentKey) {
 		if (paymentKey == null || paymentKey.isBlank()) {
-			throw PaymentDomainException.invalidStatusTransition(this.payStatus, DONE);
-		}
-		if (!this.payStatus.canTransitionTo(DONE)) {
 			throw PaymentDomainException.InvalidPaymentKey(paymentKey);
+		}
+		if (!this.payStatus.canTransitionTo(PayStatus.DONE)) {
+			throw PaymentDomainException.invalidStatusTransition(this.payStatus, PayStatus.DONE);
 		}
 		return new Payment(
 			this.paymentId,

--- a/src/main/java/com/grow/payment_service/payment/domain/model/enums/PayStatus.java
+++ b/src/main/java/com/grow/payment_service/payment/domain/model/enums/PayStatus.java
@@ -82,6 +82,7 @@ public enum PayStatus {
 			)),
 			// AUTO_BILLING_APPROVED → 다음 달 READY로 리셋
 			entry(AUTO_BILLING_APPROVED, EnumSet.of(
+				CANCEL_REQUESTED,
 				AUTO_BILLING_READY
 			)),
 			// 자동결제 승인/실패 이후 -> 종료

--- a/src/main/java/com/grow/payment_service/payment/infra/client/MemberClient.java
+++ b/src/main/java/com/grow/payment_service/payment/infra/client/MemberClient.java
@@ -9,7 +9,7 @@ import com.grow.payment_service.global.dto.RsData;
 
 @FeignClient(
 	name = "member-service",
-	url  = "http://localhost:8080",
+	url  = "${clients.member.base-url:http://localhost:8080}",
 	path = "/internal/members"
 )
 public interface MemberClient {

--- a/src/main/java/com/grow/payment_service/payment/infra/client/NotificationClient.java
+++ b/src/main/java/com/grow/payment_service/payment/infra/client/NotificationClient.java
@@ -1,0 +1,18 @@
+package com.grow.payment_service.payment.infra.client;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import com.grow.payment_service.global.dto.RsData;
+
+@FeignClient(
+	name = "notification-service",
+	url  = "${clients.notification.base-url:http://localhost:8082}",
+	path = "/notifications"
+)
+public interface NotificationClient {
+
+	@PostMapping
+	RsData<Void> sendPaymentEvent(@RequestBody NotificationRequest req);
+}

--- a/src/main/java/com/grow/payment_service/payment/infra/client/NotificationRequest.java
+++ b/src/main/java/com/grow/payment_service/payment/infra/client/NotificationRequest.java
@@ -1,0 +1,22 @@
+package com.grow.payment_service.payment.infra.client;
+
+import java.time.LocalDateTime;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class NotificationRequest {
+	@NotNull private String notificationType;
+	@NotNull private Long memberId;
+	@NotNull private String title;
+	@NotNull private String content;
+	private String orderId;
+	private Long   amount;
+	private LocalDateTime occurredAt;
+}

--- a/src/main/java/com/grow/payment_service/payment/presentation/controller/PaymentController.java
+++ b/src/main/java/com/grow/payment_service/payment/presentation/controller/PaymentController.java
@@ -60,7 +60,7 @@ public class PaymentController {
 		@Valid @RequestBody PaymentCancelRequest req
 	) {
 		PaymentCancelResponse res = paymentService.cancelPayment(
-			memberId, req.getPaymentKey(), req.getOrderId(), req.getCancelAmount(), req.getCancelReason()
+			memberId, req.getOrderId(), req.getCancelAmount(), req.getCancelReason()
 		);
 		return ResponseEntity.ok(new RsData<>("200", "결제 취소 성공", res));
 	}

--- a/src/main/java/com/grow/payment_service/payment/presentation/dto/PaymentCancelRequest.java
+++ b/src/main/java/com/grow/payment_service/payment/presentation/dto/PaymentCancelRequest.java
@@ -2,14 +2,18 @@ package com.grow.payment_service.payment.presentation.dto;
 
 import com.grow.payment_service.payment.domain.model.enums.CancelReason;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Positive;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
 public class PaymentCancelRequest {
-	private String paymentKey;
+	@NotBlank
 	private String orderId;
+
+	@Positive
 	private int cancelAmount;
 	private CancelReason cancelReason;
 }

--- a/src/main/java/com/grow/payment_service/payment/saga/PaymentSagaOrchestrator.java
+++ b/src/main/java/com/grow/payment_service/payment/saga/PaymentSagaOrchestrator.java
@@ -109,6 +109,10 @@ public class PaymentSagaOrchestrator {
 		}
 
 		try {
+			// ✅ null-safe 기본값 처리 (NPE 방지)
+			final int taxFree   = (param.getTaxFreeAmount() == null) ? 0 : param.getTaxFreeAmount();
+			final int taxExempt = (param.getTaxExemptionAmount() == null) ? 0 : param.getTaxExemptionAmount();
+
 			// 토스 자동결제 API 호출
 			TossBillingChargeResponse toss = gatewayPort.chargeWithBillingKey(
 				param.getBillingKey(),
@@ -118,8 +122,8 @@ public class PaymentSagaOrchestrator {
 				param.getOrderName(),
 				param.getCustomerEmail(),
 				param.getCustomerName(),
-				param.getTaxFreeAmount(),
-				param.getTaxExemptionAmount()
+				taxFree,          // ← null이면 0
+				taxExempt         // ← null이면 0
 			);
 
 			// DB 저장(리트라이+보상)

--- a/src/main/java/com/grow/payment_service/payment/saga/PaymentSagaOrchestrator.java
+++ b/src/main/java/com/grow/payment_service/payment/saga/PaymentSagaOrchestrator.java
@@ -29,7 +29,9 @@ public class PaymentSagaOrchestrator {
 	private final RedisIdempotencyAdapter idempotencyAdapter;
 	private final PaymentPersistenceService persistenceService;
 
+
 	/**
+	 * 결제 승인 처리
 	 * 1) 멱등키 reserve/getResult 로직으로 중복 처리 방지
 	 * 2) 토스 결제 승인 API 호출
 	 * 3) DB 저장(리트라이+보상)
@@ -81,6 +83,7 @@ public class PaymentSagaOrchestrator {
 		}
 	}
 	/**
+	 * 자동 결제 승인 처리
 	 * 1) 멱등키 reserve/getResult 로직으로 중복 처리 방지
 	 * 2) 토스 자동결제 API 호출
 	 * 3) DB 저장(리트라이+보상)
@@ -145,6 +148,7 @@ public class PaymentSagaOrchestrator {
 	}
 
 	/**
+	 * 결제 취소 처리
 	 * 1) DB 저장(취소 요청, 리트라이+보상)
 	 * 2) 토스 결제 취소 API 호출
 	 * 3) DB 저장(취소 완료, 리트라이+보상)
@@ -161,6 +165,7 @@ public class PaymentSagaOrchestrator {
 	}
 
 	/**
+	 * 빌링키 발급 처리
 	 * 1) 토스 빌링키 발급 API 호출
 	 * 2) DB 저장(리트라이+보상)
 	 */

--- a/src/main/java/com/grow/payment_service/payment/saga/PaymentSagaOrchestrator.java
+++ b/src/main/java/com/grow/payment_service/payment/saga/PaymentSagaOrchestrator.java
@@ -100,6 +100,7 @@ public class PaymentSagaOrchestrator {
 				return new PaymentConfirmResponse(
 					Long.valueOf(prev),
 					existing.getPayStatus().name(),
+					existing.getPaymentKey(),
 					param.getCustomerEmail(),
 					param.getCustomerName()
 				);

--- a/src/main/java/com/grow/payment_service/payment/saga/RetryablePersistenceService.java
+++ b/src/main/java/com/grow/payment_service/payment/saga/RetryablePersistenceService.java
@@ -36,7 +36,7 @@ public class RetryablePersistenceService {
 	@Retry(name = "dataSaveInstance", fallbackMethod = "recoverConfirm")
 	public Long saveConfirmation(String paymentKey, String orderId, int amount) {
 		log.info("[결제-Retry] 결제 승인 정보 DB 저장 시도: orderId={}", orderId);
-		return persistenceService.savePaymentConfirmation(orderId);
+		return persistenceService.savePaymentConfirmation(orderId, paymentKey);
 	}
 
 	/**

--- a/src/main/java/com/grow/payment_service/payment/saga/RetryablePersistenceService.java
+++ b/src/main/java/com/grow/payment_service/payment/saga/RetryablePersistenceService.java
@@ -131,7 +131,7 @@ public class RetryablePersistenceService {
 		log.error("[결제-Retry] 자동결제 승인 결과 DB 저장 실패, 보상 트랜잭션 실행: orderId={}, cause={}", orderId, t.toString());
 		try {
 			gatewayPort.cancelPayment(
-				billingKey,
+				tossRes.getPaymentKey(),
 				CancelReason.SYSTEM_ERROR.name(),
 				amount,
 				"보상-자동 결제 취소"

--- a/src/test/java/com/grow/payment_service/payment/application/service/impl/PaymentApplicationServiceImplTest.java
+++ b/src/test/java/com/grow/payment_service/payment/application/service/impl/PaymentApplicationServiceImplTest.java
@@ -465,7 +465,6 @@ class PaymentApplicationServiceImplTest {
 	@Test
 	@DisplayName("cancelPayment(원타임): paymentKey로 취소 호출되고 요청 금액 사용")
 	void cancelPayment_oneTime_success() {
-		// 원타임 플랜으로 오버라이드 (isAutoRenewal() = false)
 		Plan mockPlan = mock(Plan.class);
 		given(mockPlan.isAutoRenewal()).willReturn(false);
 		given(planRepository.findById(PLAN_ID)).willReturn(Optional.of(mockPlan));

--- a/src/test/java/com/grow/payment_service/payment/application/service/impl/PaymentBatchServiceImplTest.java
+++ b/src/test/java/com/grow/payment_service/payment/application/service/impl/PaymentBatchServiceImplTest.java
@@ -155,7 +155,8 @@ class PaymentBatchServiceImplTest {
 			5L,
 			PayStatus.AUTO_BILLING_APPROVED.name(),
 			"foo@ex.com",
-			"FooNick"
+			"FooNick",
+			"paymentKey-5"
 		);
 		given(paymentService.chargeWithBillingKey(
 			eq(50L),

--- a/src/test/java/com/grow/payment_service/payment/application/service/impl/PaymentPersistenceServiceImplTest.java
+++ b/src/test/java/com/grow/payment_service/payment/application/service/impl/PaymentPersistenceServiceImplTest.java
@@ -29,7 +29,6 @@ class PaymentPersistenceServiceImplTest {
 	@Mock PaymentHistoryRepository historyRepository;
 	@InjectMocks PaymentPersistenceServiceImpl service;
 
-	// helper: create a Payment in given state
 	private Payment makePayment(PayStatus status) {
 		return Payment.of(
 			123L,   // paymentId

--- a/src/test/java/com/grow/payment_service/payment/saga/PaymentSagaOrchestratorTest.java
+++ b/src/test/java/com/grow/payment_service/payment/saga/PaymentSagaOrchestratorTest.java
@@ -212,7 +212,7 @@ class PaymentSagaOrchestratorTest {
 		)).willReturn(tossCharge);
 
 		given(retryableService.saveAutoCharge("bkey", "oid", 500, tossCharge))
-			.willReturn(new PaymentConfirmResponse(99L, "DONE", "e@mail", "name"));
+			.willReturn(new PaymentConfirmResponse(99L, "DONE", "paymentkey", "e@mail", "name"));
 
 		PaymentConfirmResponse res = saga.autoChargeWithCompensation(param, "idem-key");
 

--- a/src/test/java/com/grow/payment_service/payment/saga/RetryablePersistenceServiceTest.java
+++ b/src/test/java/com/grow/payment_service/payment/saga/RetryablePersistenceServiceTest.java
@@ -106,14 +106,14 @@ class RetryablePersistenceServiceTest {
 	}
 
 	@Test
-	@DisplayName("saveConfirmation: 저장 성공 시 paymentId 반환")
+	@DisplayName("saveConfirmation: 저장 성공 시 paymentId 반환 (paymentKey 포함)")
 	void saveConfirmation_success() {
-		when(persistenceService.savePaymentConfirmation(orderId)).thenReturn(10L);
+		when(persistenceService.savePaymentConfirmation(orderId, paymentKey)).thenReturn(10L);
 
 		Long id = svc.saveConfirmation(paymentKey, orderId, amount);
 
 		assertEquals(10L, id);
-		verify(persistenceService).savePaymentConfirmation(orderId);
+		verify(persistenceService).savePaymentConfirmation(orderId, paymentKey);
 	}
 
 	@Test


### PR DESCRIPTION
## 🔍 Title(필수)
#28 



## 🔍 Test
<img width="2398" height="682" alt="스크린샷 2025-08-21 173244" src="https://github.com/user-attachments/assets/550d7fef-3f50-45a5-99b9-bf5cc0980bbe" />
<img width="1615" height="339" alt="image" src="https://github.com/user-attachments/assets/b12ce705-0aae-4d31-ae2f-50eb80d5d3f2" />
<img width="1332" height="916" alt="스크린샷 2025-08-21 173325" src="https://github.com/user-attachments/assets/4f6924f2-8219-4c68-b90d-97c10daba319" />


## 🔗 Related Issues(필수)
Closes #28 

## 📝 Note (주의 사항)
### 8월 21일 커밋만 보시면 됩니다.. 브랜치 바꾸는거 깜빡해서 여러개 들어가버렸습니다.. 🙇‍♂️🙇‍♂️🙇‍♂️🙇‍♂️🙇‍♂️

결제 알림 기능 구현했습니다. (feign client로 연결 후 이벤트-퍼블리셔 방식)
- 결제 완료
- 결제 실패
- 결제 취소
- 자동결제 등록 완료
- 자동결제 완료
- 자동결제 실패 
- 구독 해지 예약
시 알림이 전송됩니다.
추가로 알림 서비스 로그에 아직 "매칭"이 붙어있는 것이 있어서, 해당 부분 수정 후 main에 바로 push 했습니다

